### PR TITLE
relative import fix in loader modules

### DIFF
--- a/app/utils/loading.py
+++ b/app/utils/loading.py
@@ -93,7 +93,8 @@ def iter_modules(name, exclude=None, key=None):
             if re.match(e, name):
                 break
         else:
-            module = load_module(finder, name)
+            fullname = ".".join(package, name) if package else name
+            module = load_module(finder, fullname)
             if not key or key(module):
                 # don't search submodules
                 exclude.insert(0, name)


### PR DESCRIPTION
The full name of each module was not passed to `load_module`which prevented relative imports up to, and beyond the level of the module that called `load`. This was because each loader module's `__name__` was relative to the `load` caller.

For example, the `__name__` of a loader module returned by a call to `load(app, ".")` in `"mypackage"` would be `"subpackage.loader_module"` instead of `"mypackage.subpackage.loader_module"`

This is no longer the case and now `__name__` represents the full name of each module enabling relative imports from within them.