### PR TITLE
feature/iss #84 Add config for Django logger.

### DIFF
--- a/appdj/settings/__init__.py
+++ b/appdj/settings/__init__.py
@@ -1,0 +1,2 @@
+import os
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/appdj/settings/base.py
+++ b/appdj/settings/base.py
@@ -14,9 +14,9 @@ import os
 import dj_database_url
 import uuid
 from django.urls import reverse_lazy
-
+from appdj.settings import BASE_DIR
+from appdj.settings.tbslog import TBS_LOGGING
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.10/howto/deployment/checklist/
@@ -302,3 +302,5 @@ SOCIAL_AUTH_SLACK_SECRET = os.environ.get('SLACK_SECRET')
 
 # CORS requests
 CORS_ORIGIN_ALLOW_ALL = True
+
+LOGGING = TBS_LOGGING

--- a/appdj/settings/tbslog.py
+++ b/appdj/settings/tbslog.py
@@ -1,0 +1,41 @@
+import os
+from appdj.settings import BASE_DIR
+
+BASE_LOG_DIR = os.path.join(BASE_DIR, "logs/")
+
+
+def check_and_make_dir(sub_dir):
+    full_path = os.path.join(BASE_LOG_DIR, sub_dir)
+    if not os.path.isdir(full_path):
+        os.makedirs(full_path)
+    return full_path
+
+
+handlers = {}
+loggers = {}
+
+for app in ['base', 'users', 'billing', 'projects',
+            'servers', 'actions', 'infrastructure', 'triggers']:
+    app_handler = {'level': "DEBUG",
+                   'filename': os.path.join(check_and_make_dir(app), app + ".log"),
+                   'formatter': "verbose",
+                   'class': "logging.handlers.TimedRotatingFileHandler",
+                   'when': "midnight",
+                   'interval': 1}
+    handlers.update({app + "_file": app_handler})
+    app_logger = {'handlers': [app + "_file", ],
+                  'level': "DEBUG"}
+    loggers.update({app: app_logger})
+
+
+TBS_LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'format': "[%(asctime)s] %(levelname)s [%(module)s:%(filename)s:%(lineno)s] %(message)s",
+        }
+    },
+    'handlers': handlers,
+    'loggers': loggers,
+}


### PR DESCRIPTION
Add tbslog.py, change where BASE_DIR is defined so tbslog and base.py can both use it without circular imports.

Signed-off-by: John Griebel <johnkgriebel@gmail.com>