### PR TITLE
Allow openresty to fetch server info for not running servers

### DIFF
--- a/servers/tests/test_views.py
+++ b/servers/tests/test_views.py
@@ -109,26 +109,6 @@ class ServerTest(APITestCase):
         }
         self.assertDictEqual(expected, response.data)
 
-    @patch('servers.spawners.DockerSpawner.status')
-    def test_server_internal_not_running(self, server_status):
-        statuses = [
-            Server.STOPPED,
-            Server.STOPPING,
-            Server.PENDING,
-            Server.LAUNCHING,
-            Server.ERROR,
-            Server.TERMINATING,
-            Server.TERMINATED
-        ]
-        for state in statuses:
-            server_status.return_value = state
-            server = ServerFactory(project=self.project)
-            url = reverse('server_internal', kwargs={'server_pk': server.pk})
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-            expected = {'server': '', 'container_name': ''}
-            self.assertDictEqual(expected, response.data)
-
 
 class ServerRunStatisticsTestCase(APITestCase):
     def setUp(self):

--- a/servers/views.py
+++ b/servers/views.py
@@ -105,11 +105,9 @@ class IsAllowed(views.APIView):
 def server_internal_details(request, server_pk):
     server = get_object_or_404(models.Server, pk=server_pk)
     data = {'server': '', 'container_name': ''}
-    if server.status == server.RUNNING:
-        server_ip = server.get_private_ip()
-        data = {
-            'server': {service: '%s:%s' % (server_ip, port) for service, port in server.config.get('ports', {}).items()},
-            'container_name': (server.container_name or '')
-        }
-
+    server_ip = server.get_private_ip()
+    data = {
+        'server': {service: '%s:%s' % (server_ip, port) for service, port in server.config.get('ports', {}).items()},
+        'container_name': (server.container_name or '')
+    }
     return Response(data)


### PR DESCRIPTION
Fix for 3Blades/app-backend#112

Signed-off-by: Jan Kowalski <jankowalskipraca85@gmail.com>