### PR TITLE
feature/issue #155 - Get project by file name.

### DIFF
--- a/projects/serializers.py
+++ b/projects/serializers.py
@@ -58,7 +58,7 @@ class ProjectFileSerializer(serializers.ModelSerializer):
     class Meta:
         model = ProjectFile
         fields = ("id", "project", "file", "public", "base64_data", "name")
-        read_only_fields = ("author",)
+        read_only_fields = ("author", "project")
 
     def create(self, validated_data):
         project = Project.objects.get(pk=validated_data.pop("project"))

--- a/projects/tests/test_file_watcher.py
+++ b/projects/tests/test_file_watcher.py
@@ -17,8 +17,6 @@ log = logging.getLogger('projects')
 class FileWatcherTest(TestCase):
     def setUp(self):
         self.project = ProjectFactory()
-        log.debug(("DB Settings in test file", settings.DATABASES))
-        log.debug(("self.project.pk", self.project.pk))
         collaborator = CollaboratorFactory(project=self.project)
         self.user = collaborator.user
         self.user_dir = Path(settings.MEDIA_ROOT, self.user.username)


### PR DESCRIPTION
feature/issue #155 Allow retrieving a file by its name, in addition to pk. Remove project as a required field for create and update operations. Fix some unit tests.

Signed-off-by: John Griebel <jgriebel@3blades.io>