### PR TITLE
Changed header prefix for JWTs

### DIFF
--- a/appdj/settings/base.py
+++ b/appdj/settings/base.py
@@ -172,6 +172,7 @@ BCRYPT_LOG_ROUNDS = 13
 
 JWT_AUTH = {
     'JWT_EXPIRATION_DELTA': datetime.timedelta(days=30),
+    'JWT_AUTH_HEADER_PREFIX': 'Bearer',
 }
 
 # Internationalization


### PR DESCRIPTION
Currently, JWTs are passed in the headers as `Authorization: JWT <token>` which is a non-standard format. This PR changes it to `Authorization: Bearer <token>`.

Closes #193.