### PR TITLE
Attempting to update User via PATCH fails without profile object

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -36,9 +36,11 @@ class UserSerializer(SearchSerializerMixin, serializers.ModelSerializer):
         return user
 
     def update(self, instance, validated_data):
-        profile_data = validated_data.pop('profile')
-        profile = UserProfile(user=instance, **profile_data)
-        profile.save()
+        profile_data = validated_data.get('profile')
+        if profile_data is not None:
+            validated_data.pop('profile')
+            profile = UserProfile(user=instance, **profile_data)
+            profile.save()
         password = validated_data.pop('password', None)
         if password is not None:
             instance.set_password(password)

--- a/users/tests/test_views.py
+++ b/users/tests/test_views.py
@@ -1,9 +1,11 @@
 from django.urls import reverse
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from rest_framework import status
 from rest_framework.test import APITestCase
 
 from users.tests.factories import UserFactory, EmailFactory
+User = get_user_model()
 
 
 class UserTest(APITestCase):
@@ -26,6 +28,16 @@ class UserTest(APITestCase):
                                              'version': settings.DEFAULT_VERSION})
         response = self.user_client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_patch_user_without_profile(self):
+        user = UserFactory()
+        url = reverse("user-detail", kwargs={'pk': user.pk,
+                                             'version': settings.DEFAULT_VERSION})
+        data = {'first_name': "Tom"}
+        response = self.admin_client.patch(url, data=data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        user_reloaded = User.objects.get(pk=user.pk)
+        self.assertEqual(user_reloaded.first_name, "Tom")
 
 
 class EmailTest(APITestCase):


### PR DESCRIPTION
fix/issue #207 - Change UserSerializer.update so that it will not require the profile oject to process a PATCH request.

Signed-off-by: John Griebel <jgriebel@3blades.io>