### PR TITLE
Fix Project PATCH operation.

### DIFF
--- a/projects/serializers.py
+++ b/projects/serializers.py
@@ -24,7 +24,10 @@ class ProjectSerializer(SearchSerializerMixin, serializers.ModelSerializer):
 
     def validate_name(self, value):
         request = self.context['request']
-        if Project.objects.filter(name=value, collaborator__user=request.user, collaborator__owner=True).exists():
+        existing_pk = self.context.get("pk")
+        if Project.objects.filter(name=value,
+                                  collaborator__user=request.user,
+                                  collaborator__owner=True).exclude(pk=existing_pk).exists():
             raise serializers.ValidationError("You can have only one project named %s" % value)
         return value
 

--- a/projects/serializers.py
+++ b/projects/serializers.py
@@ -27,6 +27,7 @@ class ProjectSerializer(SearchSerializerMixin, serializers.ModelSerializer):
         existing_pk = self.context.get("pk")
         if Project.objects.filter(name=value,
                                   collaborator__user=request.user,
+                                  collaborator__user__is_active=True,
                                   collaborator__owner=True).exclude(pk=existing_pk).exists():
             raise serializers.ValidationError("You can have only one project named %s" % value)
         return value

--- a/projects/tests/test_views.py
+++ b/projects/tests/test_views.py
@@ -126,13 +126,12 @@ class ProjectTest(ProjectTestMixin, APITestCase):
         url = reverse('project-detail', kwargs={'namespace': self.user.username,
                                                 'pk': project.pk,
                                                 'version': settings.DEFAULT_VERSION})
-        data = dict(
-            name='Test-1',
-        )
+        data = {'description': "Foo",
+                'name': project.name}
         response = self.client.patch(url, data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         project = Project.objects.get(pk=project.pk)
-        self.assertEqual(project.name, data['name'])
+        self.assertEqual(project.description, data['description'])
 
     def test_project_delete(self):
         collaborator = CollaboratorFactory(user=self.user)

--- a/projects/views.py
+++ b/projects/views.py
@@ -26,6 +26,19 @@ class ProjectViewSet(NamespaceMixin, viewsets.ModelViewSet):
     filter_fields = ('private', 'name')
     ordering_fields = ('name',)
 
+    def partial_update(self, request, *args, **kwargs):
+        instance = Project.objects.get(pk=kwargs.get("pk"))
+        update_data = request.data
+
+        serializer = self.serializer_class(instance, data=update_data,
+                                           context={'request': request,
+                                                    'pk': instance.pk})
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        return Response(data=serializer.data,
+                        status=status.HTTP_200_OK)
+
 
 class ProjectMixin(object):
     permission_classes = (permissions.IsAuthenticated, ProjectChildPermission)


### PR DESCRIPTION
fix/issue #204 - Adjust project view, serializer, and tests to handle PATCHing an existing project using the same name.

Signed-off-by: John Griebel <jgriebel@3blades.io>