### PR TITLE
Do nothing if an admin user already exists. Invoke watchman trigger.

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,5 +7,6 @@ sleep 1
 /srv/env/bin/python /srv/app/manage.py create_admin
 /srv/env/bin/python /srv/app/manage.py create_resource
 /srv/env/bin/python /srv/app/manage.py site_host
+/srv/app/watchman_trigger.sh
 
 exec "$@"

--- a/users/management/commands/create_admin.py
+++ b/users/management/commands/create_admin.py
@@ -14,9 +14,13 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         User = get_user_model()
         try:
-            user = User.objects.create_superuser("admin", "admin@example.com", "admin")
-            Token.objects.create(user=user)
-            profile, created = UserProfile.objects.get_or_create(user=user)
+            admin_exists = User.objects.filter(username="admin", is_active=True).exists()
+            if admin_exists:
+                log.info("Admin user already exists. Doing nothing.")
+            else:
+                user = User.objects.create_superuser("admin", "admin@example.com", "admin")
+                Token.objects.create(user=user)
+                profile, created = UserProfile.objects.get_or_create(user=user)
 
             if created:
                 log.info("Created a User Profile for the admin user: {prof}".format(prof=profile))


### PR DESCRIPTION
fix/issue #227 - Restarting services duplicates users.
Signed-off-by: John Griebel <jgriebel@3blades.io>