### PR TITLE
Webhook serialization error fix

### DIFF
--- a/triggers/serializers.py
+++ b/triggers/serializers.py
@@ -38,6 +38,9 @@ class WebhookSerializer(serializers.Serializer):
     url = serializers.URLField()
     config = serializers.JSONField(required=False)
 
+    def to_representation(self, obj):
+        return obj
+
 
 class TriggerSerializer(serializers.ModelSerializer):
     cause = TriggerActionSerializer(required=False)


### PR DESCRIPTION
Signed-off-by: Jan Kowalski <jankowalskipraca85@gmail.com>

Added this because we got error while accessing triggers list due to wrong webhook representation.