### PR TITLE
Generate random images without numpy. 

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,5 +2,4 @@
 factory-boy==2.8.1
 fakeredis==0.8.2
 django-debug-toolbar==1.6
-numpy==1.13.1
 https://github.com/3Blades/django-swagger-docs/archive/master.zip

--- a/users/tests/utils.py
+++ b/users/tests/utils.py
@@ -1,9 +1,11 @@
-import numpy
+from random import randint
 from PIL import Image
 
 
-def generate_random_image(name):
+def generate_random_image(name, height=100, width=100):
     # Thanks Stack OverFlow: https://stackoverflow.com/a/15262028/5627654
-    image_array = numpy.random.rand(100, 100, 3) * 255
-    image = Image.fromarray(image_array.astype('uint8')).convert("RGBA")
+    red = randint(0, 255)
+    green = randint(0, 255)
+    blue = randint(0, 255)
+    image = Image.new(mode="RGB", size=(height, width), color=(red, green, blue))
     image.save("/tmp/" + name)


### PR DESCRIPTION
fix/issue #279 - Remove numpy as a requirement. 

Signed-off-by: John Griebel <jgriebel@3blades.io>