### PR TITLE
Adjust billing customer signal to receive on user creation

### DIFF
--- a/actions/tests/test_views.py
+++ b/actions/tests/test_views.py
@@ -28,8 +28,8 @@ class ActionTest(APITestCase):
 
     def test_list_actions(self):
         ActionFactory(content_object=PlanFactory())
-        ActionFactory(content_object=CardFactory())
-        ActionFactory(content_object=SubscriptionFactory())
+        ActionFactory(content_object=CardFactory(customer=self.user.customer))
+        ActionFactory(content_object=SubscriptionFactory(customer=self.user.customer))
         ActionFactory(content_object=DockerHostFactory())
         ActionFactory(content_object=ProjectFactory())
         ActionFactory(content_object=CollaboratorFactory())

--- a/billing/signals.py
+++ b/billing/signals.py
@@ -1,24 +1,22 @@
-from django.conf import settings
-from django.contrib.auth.signals import user_logged_in
+import logging
+from django.contrib.auth import get_user_model
+from django.db.models.signals import post_save
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
 from billing.models import Customer, Plan
 from billing.stripe_utils import create_stripe_customer_from_user, create_plan_in_stripe
-import logging
-log = logging.getLogger('billing')
+log = logging.getLogger("billing")
 
 
-def check_if_customer_exists_for_user(sender, **kwargs):
-    user = kwargs.get("user")
-    if settings.ENABLE_BILLING:
-        try:
-            user.customer
-        except Customer.DoesNotExist:
-            log.info("No stripe customer exists for user {uname}. "
-                     "Creating one.".format(uname=user.username))
-            create_stripe_customer_from_user(user)
-
-user_logged_in.connect(check_if_customer_exists_for_user)
+@receiver(post_save, sender=get_user_model())
+def check_if_customer_exists_for_user(sender, instance, created, **kwargs):
+    user = instance
+    try:
+        user.customer
+    except Customer.DoesNotExist:
+        log.info("No stripe customer exists for user {uname}. "
+                 "Creating one.".format(uname=user.username))
+        create_stripe_customer_from_user(user)
 
 
 @receiver(pre_save, sender=Plan)

--- a/billing/tests/factories.py
+++ b/billing/tests/factories.py
@@ -50,7 +50,7 @@ class CardFactory(factory.django.DjangoModelFactory):
     metadata = None
     livemode = False
 
-    customer = factory.SubFactory(CustomerFactory)
+    customer = None
     # Note: This will clearly not generate valid addresses.
     # This should be used only for testing our own API, and not requests made to Stripe
     name = fuzzy.FuzzyText(length=200)
@@ -80,7 +80,7 @@ class SubscriptionFactory(factory.django.DjangoModelFactory):
     metadata = None
     livemode = False
 
-    customer = factory.SubFactory(CustomerFactory)
+    customer = None
     plan = factory.SubFactory(PlanFactory)
     application_fee_percent = fuzzy.FuzzyDecimal(low=0, high=1)
     cancel_at_period_end = fuzzy.FuzzyChoice([True, False])

--- a/billing/tests/test_middleware.py
+++ b/billing/tests/test_middleware.py
@@ -4,15 +4,17 @@ from django.test import override_settings
 from rest_framework.test import APITestCase
 from users.tests.factories import UserFactory
 from rest_framework import status
-from billing.tests.factories import CustomerFactory, SubscriptionFactory
+from billing.tests.factories import SubscriptionFactory
 
 
 class TestMiddleware(APITestCase):
     def setUp(self):
-        self.user = UserFactory(is_staff=False)
+        self.user = UserFactory()
+        self.user.is_staff = False
+        self.user.save()
         self.token_header = "Token {auth}".format(auth=self.user.auth_token.key)
         self.client = self.client_class(HTTP_AUTHORIZATION=self.token_header)
-        self.customer = CustomerFactory(user=self.user)
+        self.customer = self.user.customer
 
     @override_settings(ENABLE_BILLING=True)
     def test_no_subscription_is_rejected(self):
@@ -23,8 +25,8 @@ class TestMiddleware(APITestCase):
 
     @override_settings(ENABLE_BILLING=True)
     def test_valid_subscription_accepted(self):
-        _ = SubscriptionFactory(customer=self.customer,
-                                status="active")
+        SubscriptionFactory(customer=self.customer,
+                            status="active")
         url = reverse("project-list", kwargs={'version': settings.DEFAULT_VERSION,
                                               'namespace': self.user.username})
         response = self.client.get(url)

--- a/billing/tests/test_signals.py
+++ b/billing/tests/test_signals.py
@@ -1,5 +1,4 @@
 from django.test import TestCase
-from rest_framework.test import APIClient
 from billing.models import Plan, Customer
 from billing.tests.factories import PlanFactory
 from users.tests.factories import UserFactory
@@ -21,8 +20,6 @@ class TestBillingSignals(TestCase):
 
     def test_customer_created_on_first_login(self):
         user = UserFactory()
-        client = APIClient()
-        client.force_login(user=user)
         customers = Customer.objects.filter(user=user)
         self.assertTrue(customers.exists())
         self.assertEqual(customers.count(), 1)

--- a/billing/tests/test_views.py
+++ b/billing/tests/test_views.py
@@ -101,7 +101,9 @@ class CardTest(APITestCase):
 
     def test_list_cards(self):
         not_me_card_count = 3
-        cards = CardFactory.create_batch(not_me_card_count)
+        for _ in range(not_me_card_count):
+            user = UserFactory()
+            CardFactory(customer=user.customer)
         my_card_count = 2
         my_cards = CardFactory.create_batch(my_card_count, customer=self.customer)
         url = reverse("card-list", kwargs={'namespace': self.user.username,
@@ -198,8 +200,13 @@ class SubscriptionTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
     def test_list_subscriptions(self):
+        import logging
+        log = logging.getLogger("billing")
         not_me_sub_count = 3
-        other_subs = SubscriptionFactory.create_batch(not_me_sub_count)
+        for _ in range(not_me_sub_count):
+            user = UserFactory()
+            log.debug(("test user.pk", user.pk))
+            SubscriptionFactory(customer=user.customer)
         my_subs_count = 2
         my_subs = SubscriptionFactory.create_batch(my_subs_count, customer=self.customer)
         url = reverse("subscription-list", kwargs={'namespace': self.user.username,

--- a/servers/tests/test_views.py
+++ b/servers/tests/test_views.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 from guardian.shortcuts import assign_perm
 from django.urls import reverse
 from django.conf import settings
+from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -236,6 +237,7 @@ class ServerStatisticsTestCase(APITestCase):
         self.assertDictEqual(response.data, expected)
 
 
+@override_settings(ENABLE_BILLING=False)
 class ServerSizeTestCase(APITestCase):
     def setUp(self):
         self.user = UserFactory()
@@ -252,7 +254,9 @@ class ServerSizeTestCase(APITestCase):
         self.assertEqual(response.data.get("id"), str(self.server_size.pk))
 
     def test_non_staff_cannot_create_server_size(self):
-        non_staff = UserFactory(is_staff=False)
+        non_staff = UserFactory()
+        non_staff.is_staff = False
+        non_staff.save()
         token_header = 'Token {}'.format(non_staff.auth_token.key)
         client = self.client_class(HTTP_AUTHORIZATION=token_header)
 

--- a/users/tests/factories.py
+++ b/users/tests/factories.py
@@ -29,6 +29,8 @@ class UserFactory(factory.django.DjangoModelFactory):
         post_save.disconnect(create_user_ssh_key, User)
         user = super()._generate(create, attrs)
         Token.objects.create(user=user)
+        user.is_staff = True
+        user.save()
         post_save.connect(create_user_ssh_key, User)
         return user
 

--- a/users/tests/test_views.py
+++ b/users/tests/test_views.py
@@ -10,6 +10,8 @@ from django.core import mail
 from rest_framework import status
 from rest_framework.test import APITestCase, APIClient
 
+from billing.tests.factories import SubscriptionFactory
+from billing.models import Subscription
 from users.tests.factories import UserFactory, EmailFactory
 from users.tests.utils import generate_random_image
 from utils import create_ssh_key
@@ -33,6 +35,11 @@ class UserTest(APITestCase):
     def setUp(self):
         self.admin = UserFactory(is_staff=True, username='admin')
         self.user = UserFactory(username='user')
+        self.user.is_staff = False
+        self.user.save()
+        SubscriptionFactory(customer=self.user.customer,
+                            plan__trial_period_days=7,
+                            status=Subscription.ACTIVE)
         self.admin_client = self.client_class(HTTP_AUTHORIZATION='Token {}'.format(self.admin.auth_token.key))
         self.user_client = self.client_class(HTTP_AUTHORIZATION='Token {}'.format(self.user.auth_token.key))
         self.to_remove = []


### PR DESCRIPTION
[fix]/issue #338 - API Testing Errors. Fix Customer instantiation so that it happens when a user is created. This way a user doesn't have to log in for a customer to be created, making automated API testing easier.

Signed-off-by: John Griebel <jgriebel@3blades.io>