### PR TITLE
Ensure collaborators with write perms will be created with read perm

### DIFF
--- a/projects/permissions.py
+++ b/projects/permissions.py
@@ -5,7 +5,8 @@ def has_project_permission(request, project):
     if project.private is False and request.method in permissions.SAFE_METHODS:
         return True
     if request.method in permissions.SAFE_METHODS:
-        return request.user.has_perm('read_project', project)
+        return (request.user.has_perm('read_project', project)
+                or request.user.has_perm('write_project', project))
     else:
         return request.user.has_perm('write_project', project)
 

--- a/projects/utils.py
+++ b/projects/utils.py
@@ -53,6 +53,7 @@ def assign_to_user(request, project):
     log.info(f"Creating default collaborator, assigning permissions, and creating project resource root.")
     Collaborator.objects.create(project=project, owner=True, user=user)
     assign_perm('write_project', request.user, project)
+    assign_perm('read_project', request.user, project)
 
 
 def assign_to_team(request, project):

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,3 +3,4 @@ factory-boy==2.8.1
 fakeredis==0.8.2
 django-debug-toolbar==1.6
 https://github.com/3Blades/django-swagger-docs/archive/master.zip
+coverage==4.4.1


### PR DESCRIPTION
Also make sure that existing collaborator records with only `write_permission` will be treated as having `read_permission` as well.
Closes #495 
Signed-off-by: John Griebel <jgriebel@3blades.io>